### PR TITLE
match python interpreter with either a _cpython build string, or simply a build number

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,22 +8,22 @@ python_abi_tag:
  - cp314t
 
 python_impl_version:
- - 3.10
- - 3.11
- - 3.12
- - 3.13
- - 3.13
- - 3.14
- - 3.14
+ - "3.10"
+ - "3.11"
+ - "3.12"
+ - "3.13"
+ - "3.13"
+ - "3.14"
+ - "3.14"
 
 python_version:
- - 3.10
- - 3.11
- - 3.12
- - 3.13
- - 3.13
- - 3.14
- - 3.14
+ - "3.10"
+ - "3.11"
+ - "3.12"
+ - "3.13"
+ - "3.13"
+ - "3.14"
+ - "3.14"
 
 python_implementation:
  - cpython
@@ -40,9 +40,22 @@ zip_keys:
    - python_version
    - python_impl_version
    - python_implementation
+   - python
 
 # to help PBP generate a proper build graph
 python:
-  - "3.13"
+ - "3.10"
+ - "3.11"
+ - "3.12"
+ - "3.13"
+ - "3.13"
+ - "3.14"
+ - "3.14"
 numpy:
+  - "2.1"
+  - "2.1"
+  - "2.1"
+  - "2.1"
+  - "2.1"
+  - "2.1"
   - "2.1"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 {% if python_impl_version is not defined %}
 {% set python_impl_version = "3.8" %}
 {% endif %}
@@ -25,7 +25,10 @@ requirements:
     {% if python_minor >= 13 %}
     - python {{ python_version }}.* *_{{ python_abi_tag }}                                         # [python_implementation == "cpython"]
     {% else %}
-    - python {{ python_version }}.* *_cpython                                                      # [python_implementation == "cpython"]
+    # anaconda's python interpreters prior to 3.13 only have build numbers, and conda-forge's interpreters use suffix _cpython
+    # conda does not handle well OR operators in build strings
+    # This regex matches any build string that does not end with _graalpy or _pypy
+    - python {{ python_version }}.* ^(?!.*_graalpy$)(?!.*_pypy$).*$                                # [python_implementation == "cpython"]
     {% endif %}
     - python {{ python_version }}.* *_{{ python_impl_version.replace('.', '') }}_pypy              # [python_implementation == "pypy"]
     - python {{ python_version }}.* *_native{{ python_impl_version.replace('.', '') }}_graalpy     # [python_implementation == "graalpy"]


### PR DESCRIPTION
Match python interpreter before 3.13 with either a _cpython build string (conda-forge), or simply a build number (anaconda).

Since matchspec parsing is buggy regarding OR statements (see https://github.com/conda/conda/issues/15385), the check is instead to not match _graalpy or _pypy, the only other python variants published before python 3.13 on conda-forge.

https://anaconda.atlassian.net/browse/PKG-10755