### PR TITLE
Add py315 support

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -44,7 +44,6 @@ zip_keys:
    - python_version
    - python_impl_version
    - python_implementation
-   - python
 
 # to help PBP generate a proper build graph
 python:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,7 +6,8 @@ python_abi_tag:
  - cp313t
  - cp314
  - cp314t
-
+ - cp315
+ - cp315t
 python_impl_version:
  - "3.10"
  - "3.11"
@@ -15,7 +16,8 @@ python_impl_version:
  - "3.13"
  - "3.14"
  - "3.14"
-
+ - "3.15"
+ - "3.15"
 python_version:
  - "3.10"
  - "3.11"
@@ -24,7 +26,8 @@ python_version:
  - "3.13"
  - "3.14"
  - "3.14"
-
+ - "3.15"
+ - "3.15"
 python_implementation:
  - cpython
  - cpython
@@ -33,7 +36,8 @@ python_implementation:
  - cpython
  - cpython
  - cpython
-
+ - cpython
+ - cpython
 zip_keys:
  -
    - python_abi_tag
@@ -51,6 +55,8 @@ python:
  - "3.13"
  - "3.14"
  - "3.14"
+ - "3.15"
+ - "3.15"
 numpy:
   - "2.1"
   - "2.1"
@@ -59,3 +65,8 @@ numpy:
   - "2.1"
   - "2.1"
   - "2.1"
+  # TODO: numpy 2.6.0 is not released yet;
+  # upstream says py315 support starts with Python 3.15.0rc1 (~Jul 2026)
+  # keep 2.4 for now. Recheck when 2.6.0 is released.
+  - "2.4"
+  - "2.4"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -68,5 +68,5 @@ numpy:
   # TODO: numpy 2.6.0 is not released yet;
   # upstream says py315 support starts with Python 3.15.0rc1 (~Jul 2026)
   # keep 2.4 for now. Recheck when 2.6.0 is released.
-  - "2.4"
-  - "2.4"
+  - "2.5"
+  - "2.5"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,6 @@ requirements:
     - python {{ python_version }}.* *_native{{ python_impl_version.replace('.', '') }}_graalpy     # [python_implementation == "graalpy"]
 
 test:
-  requires:
-    # FIXME: remove this once we are able to build new minor versions of Python on CI.
-    - python 3.14  # [py==315]
   commands:
     - echo "hello"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,9 @@ build:
     - native_graalpy      # [python_implementation == "graalpy"]
 
 requirements:
+  build:
+    # Python is needed for PBP.
+    - python
   run_constrained:
     {% if python_minor >= 13 %}
     - python {{ python_version }}.* *_{{ python_abi_tag }}                                         # [python_implementation == "cpython"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,9 @@ build:
     - native_graalpy      # [python_implementation == "graalpy"]
 
 requirements:
+  build:
+    # FIXME: remove this once we are able to build new minor versions of Python on CI.
+    - python 3.14
   run_constrained:
     {% if python_minor >= 13 %}
     - python {{ python_version }}.* *_{{ python_abi_tag }}                                         # [python_implementation == "cpython"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 3 %}
+{% set build_num = 4 %}
 {% if python_impl_version is not defined %}
 {% set python_impl_version = "3.8" %}
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,6 @@ build:
     - native_graalpy      # [python_implementation == "graalpy"]
 
 requirements:
-  build:
-    # FIXME: remove this once we are able to build new minor versions of Python on CI.
-    - python 3.14
   run_constrained:
     {% if python_minor >= 13 %}
     - python {{ python_version }}.* *_{{ python_abi_tag }}                                         # [python_implementation == "cpython"]
@@ -44,6 +41,9 @@ requirements:
     - python {{ python_version }}.* *_native{{ python_impl_version.replace('.', '') }}_graalpy     # [python_implementation == "graalpy"]
 
 test:
+  requires:
+    # FIXME: remove this once we are able to build new minor versions of Python on CI.
+    - python 3.14  # [py==315]
   commands:
     - echo "hello"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,11 @@ build:
   track_features:         # [python_implementation != "cpython"]
     - pypy                # [python_implementation == "pypy"]
     - native_graalpy      # [python_implementation == "graalpy"]
+  # Required for PBP.
+  force_ignore_keys:
+    - python
 
 requirements:
-  build:
-    # Python is needed for PBP.
-    - python
   run_constrained:
     {% if python_minor >= 13 %}
     - python {{ python_version }}.* *_{{ python_abi_tag }}                                         # [python_implementation == "cpython"]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-15602) 
- [Upstream repository](https://github.com/conda-forge/python_abi-feedstock/blob/main/recipe/meta.yaml)

### Explanation of changes:

- Add py315 and py315t
- Bump the build number to 4

### Notes:

- numpy is not in zip_keys. I added 2.4 for p315, but later we should bump it to 2.5 or 2.6 for PBP